### PR TITLE
Fix duplicate param definition

### DIFF
--- a/enhance.py
+++ b/enhance.py
@@ -36,7 +36,6 @@ parser = argparse.ArgumentParser(description='Generate a new image by applying s
 add_arg = parser.add_argument
 add_arg('files',                nargs='*', default=[])
 add_arg('--scales',             default=2, type=int,                help='How many times to perform 2x upsampling.')
-add_arg('--model',              default='medium', type=str,         help='Name of the neural network to load/save.')
 add_arg('--model',              default='small', type=str,          help='Name of the neural network to load/save.')
 add_arg('--train',              default=False, type=str,            help='File pattern to load for training.')
 add_arg('--batch-resolution',   default=192, type=int,              help='Resolution of images in training batch.')


### PR DESCRIPTION
Caused by https://github.com/alexjc/neural-enhance/commit/203917d1227e3c5b26668aefe481cc1756bee42f - currently producing this error:

```
Traceback (most recent call last):
  File "enhance.py", line 40, in <module>
    add_arg('--model',              default='small', type=str,          help='Name of the neural network to load/save.')
  File "/opt/conda/lib/python3.5/argparse.py", line 1344, in add_argument
    return self._add_action(action)
  File "/opt/conda/lib/python3.5/argparse.py", line 1707, in _add_action
    self._optionals._add_action(action)
  File "/opt/conda/lib/python3.5/argparse.py", line 1548, in _add_action
    action = super(_ArgumentGroup, self)._add_action(action)                                                                                                              
  File "/opt/conda/lib/python3.5/argparse.py", line 1358, in _add_action                                                                                                  
    self._check_conflict(action)                                                                                                                                          
  File "/opt/conda/lib/python3.5/argparse.py", line 1497, in _check_conflict                                                                                              
    conflict_handler(action, confl_optionals)
  File "/opt/conda/lib/python3.5/argparse.py", line 1506, in _handle_conflict_error
    raise ArgumentError(action, message % conflict_string)
argparse.ArgumentError: argument --model: conflicting option string: --model
```