### PR TITLE
Remove cnmem theano flag

### DIFF
--- a/enhance.py
+++ b/enhance.py
@@ -96,7 +96,7 @@ print("""{}   {}Super Resolution for images and videos powered by Deep Learning!
 # Load the underlying deep learning libraries based on the device specified.  If you specify THEANO_FLAGS manually,
 # the code assumes you know what you are doing and they are not overriden!
 os.environ.setdefault('THEANO_FLAGS', 'floatX=float32,device={},force_device=True,allow_gc=True,'\
-                                      'print_active_device=False,lib.cnmem=1.0'.format(args.device))
+                                      'print_active_device=False'.format(args.device))
 
 # Scientific & Imaging Libraries
 import numpy as np


### PR DESCRIPTION
If you're sharing your GPU with your display, using 100% of memory with lib.cnmem=1 fails with CNMEM_STATUS_OUT_OF_MEMORY.  I was able to make cnmem work with a 0.8 value, but not 0.9.  I think it depends on the size of your GPU mem vs the resolution of your display so there's no 'best value.'  

Since the comment says if you know what you're doing you can change it, then it's probably best to have failsafe defaults for beginners, so this just doesn't use cnmem at all.

fixes #19 