### PR TITLE
remove deprecated package from enhance.py

### DIFF
--- a/enhance.py
+++ b/enhance.py
@@ -29,6 +29,7 @@ import argparse
 import itertools
 import threading
 import collections
+import imageio
 
 
 # Configure all options first so we can later custom-load other libraries (Theano) based on device specified by user.
@@ -580,7 +581,7 @@ if __name__ == "__main__":
         enhancer = NeuralEnhancer(loader=False)
         for filename in args.files:
             print(filename, end=' ')
-            img = scipy.ndimage.imread(filename, mode='RGB')
+            img = imageio.imread(filename, pilmode='RGB')
             out = enhancer.process(img)
             out.save(os.path.splitext(filename)[0]+'_ne%ix.png' % args.zoom)
             print(flush=True)


### PR DESCRIPTION
scipy.ndimage.imread was deprecated in 2017 with the release of scipy 1.0 and finally removed in 1.2.0 (see issue [#229](https://github.com/alexjc/neural-enhance/issues/229)) 

There is however documentation for transitioning to imageio [here ](https://docs.scipy.org/doc/scipy-1.1.0/reference/generated/scipy.ndimage.imread.html#scipy.ndimage.imread) The most relevant change is instead of mode use the pilmode keyword argument.

imageio is documented [here](https://imageio.readthedocs.io/en/stable/installation.html)
